### PR TITLE
Fortunes: omit missing values so they aren't printed

### DIFF
--- a/R/say.r
+++ b/R/say.r
@@ -113,6 +113,7 @@ say <- function(what="Hello world!", by="cat", type="message", length=18, fortun
   if (what == "fortune") {
     if ( is.null(fortune) ) fortune <- sample(1:360, 1)
     what <- fortune(which = fortune, ...)
+    what <- what[!is.na(what)] # remove missing pieces (e.g. "context")
     what <- gsub("<x>", "\n", paste(as.character(what), collapse = "\n "))
   }
   if (what == "iheart") {


### PR DESCRIPTION
 - For example, consider `cowsay::say(fortune=7)`; there's a line with "`NA`"
   for (the "context").