### PR TITLE
subset animals on windows for when by='random'

### DIFF
--- a/R/get_who.R
+++ b/R/get_who.R
@@ -4,10 +4,13 @@ get_who <- function(by, length) {
   if (.Platform$OS.type == "windows") {
     ua <- c('shortcat','longcat','fish','signbunny','stretchycat',
             'anxiouscat','longtailcat','grumpycat','mushroom')
+    
     if (by %in% ua) {
       stop("If you're on Windows, you can't use:\n", 
            paste0(sort(ua), collapse = "\n"), call. = FALSE)
     }
+    
+    animals <- animals[setdiff(names(animals), ua)]
   }
   
   by <- match.arg(by, c(choices = names(animals), "rms", "random"))

--- a/tests/testthat/test-say.R
+++ b/tests/testthat/test-say.R
@@ -19,3 +19,9 @@ test_that("say by works as expected", {
 test_that("say fails well", {
   expect_error(say(list(4, 5)), "what has to be of length 1")
 })
+
+test_that("say fails with certain characters on windows", {
+  skip_on_os(c("mac", "linux", "solaris"))
+  expect_error(say("Hi", by = "longcat"), "If you're on Windows, you can't use")
+})
+


### PR DESCRIPTION
Sorry to do this just after CRAN submission, but I didn't notice the change in dealing with unicode on windows until I installed from CRAN today.

When you set `by = 'random'` (on Windows), it passes the `stop` on line 8, but the full list of animals is still available to sample from, resulting in a bad unicode animal showing up once in a while.

This PR subsets the `animals` vector by removing the animals defined in `ua`