### PR TITLE
Default to type="print" in noninteractive mode

### DIFF
--- a/R/say.r
+++ b/R/say.r
@@ -13,9 +13,9 @@
 #' We use \code{\link{match.arg}} internally, so you can use unique parts of
 #' words that don't conflict with others, like "g" for "ghost" because there's 
 #' no other animal that starts with "g".
-#' @param type (character) One of message (default), warning, or string 
-#' (returns string). If multiple colors are supplied to \code{what_color} or 
+#' @param type (character) One of message (default), warning, print (default in non-interactive mode), or string (returns string). If multiple colors are supplied to \code{what_color} or 
 #' \code{by_color}, type cannot be warning. (This is a limitation of the \href{https://github.com/aedobbyn/multicolor}{multicolor} packcage :/.)
+#' If run in non-interactive mode default type is print, so that output goes to stdout rather than stderr, where messages and warnings go. 
 #' @param what_color (character or crayon function) One or more 
 #' \href{https://github.com/r-lib/crayon#256-colors}{\code{crayon}}-suported text color(s) 
 #' or \href{https://github.com/r-lib/crayon#styles}{\code{crayon style function}} to color
@@ -124,7 +124,7 @@
 #' say(fortune=59, by="clippy")
 
 say <- function(what="Hello world!", by="cat", 
-                type="message", 
+                type=NULL, 
                 what_color=NULL, by_color=NULL,  
                 length=18, fortune=NULL, ...) {
 
@@ -139,6 +139,14 @@ say <- function(what="Hello world!", by="cat",
   } else {
     what_color <- check_color(what_color)
     by_color <- check_color(by_color)
+  }
+  
+  if (is.null(type)) {
+    if (interactive()) {
+      type <- "message"
+    } else {
+      type <- "print"
+    }
   }
 
   if (what == "catfact") {
@@ -232,5 +240,6 @@ say <- function(what="Hello world!", by="cat",
   switch(type,
          message = message(out),
          warning = warning(out),
+         print = cat(out),
          string = out)
 }

--- a/man/say.Rd
+++ b/man/say.Rd
@@ -4,7 +4,7 @@
 \alias{say}
 \title{Sling messages and warnings with flair}
 \usage{
-say(what = "Hello world!", by = "cat", type = "message",
+say(what = "Hello world!", by = "cat", type = NULL,
   what_color = NULL, by_color = NULL, length = 18, fortune = NULL,
   ...)
 }
@@ -22,9 +22,9 @@ We use \code{\link{match.arg}} internally, so you can use unique parts of
 words that don't conflict with others, like "g" for "ghost" because there's 
 no other animal that starts with "g".}
 
-\item{type}{(character) One of message (default), warning, or string 
-(returns string). If multiple colors are supplied to \code{what_color} or 
-\code{by_color}, type cannot be warning. (This is a limitation of the \href{https://github.com/aedobbyn/multicolor}{multicolor} packcage :/.)}
+\item{type}{(character) One of message (default), warning, print (default in non-interactive mode), or string (returns string). If multiple colors are supplied to \code{what_color} or 
+\code{by_color}, type cannot be warning. (This is a limitation of the \href{https://github.com/aedobbyn/multicolor}{multicolor} packcage :/.)
+If run in non-interactive mode default type is print, so that output goes to stdout rather than stderr, where messages and warnings go.}
 
 \item{what_color}{(character or crayon function) One or more 
 \href{https://github.com/r-lib/crayon#256-colors}{\code{crayon}}-suported text color(s) 

--- a/tests/testthat/test-say.R
+++ b/tests/testthat/test-say.R
@@ -17,32 +17,36 @@ test_that("say types works as expected", {
     length(suppressWarnings(say("foo", type = "warning")))
   )
   
-  expect_silent(
-    suppressMessages(say(what = "rms", by = "rms", 
+  expect_equal(
+    say(what = "rms", by = "rms",
         what_color = yellow$bgMagenta$bold,
-        by_color = cyan$italic))
+        by_color = cyan$italic),
+    say(what = "rms", by = "rms", type = "print")
   )
   
-  expect_silent(
-    suppressMessages(say(what = "I'm a rare Irish buffalo", 
-        by = "buffalo", what_color = "pink", 
-        by_color = c("green", "white", "orange")))
+  expect_equal(
+    say(what = "I'm a rare Irish buffalo", 
+        by = "buffalo", 
+        what_color = "pink", 
+        by_color = c("green", "white", "orange")),
+    say(what = "I'm a rare Irish buffalo", 
+        by = "buffalo",
+        type = "print")
   )
   
-  expect_silent(
-    suppressMessages(
-      say("I'm not dying, you're dying", "yoda", 
-          what_color = "green",
-          by_color = colors())
-    )
+  expect_equal(
+    say("I'm not dying, you're dying", "yoda",
+        what_color = "green",
+        by_color = colors()),
+    say("I'm not dying, you're dying", "yoda",
+        type = "print")
   )
-  
-  expect_silent(
-    suppressMessages(
-      say("asdfghjkl;'", "chicken", 
+
+  expect_equal(
+    say("asdfghjkl;'", "chicken",
           what_color = blue,
-          by_color = c("rainbow", colors()[sample(100, 1)], "rainbow"))
-    )
+          by_color = c("rainbow", colors()[sample(100, 1)], "rainbow")),
+    say("asdfghjkl;'", "chicken", type = "print")
   )
 
   # hypnotoad can say anything


### PR DESCRIPTION
The way I'm handling the default `type` now is to set it to null by default and then assign it to "message" if in interactive and "print" if in noninteractive mode to address the other half of #70. Otherwise, `type` is whatever the user specifies. 

If there's a different approach, happy to change it up!